### PR TITLE
Fix xcode 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Fixed iOS 18 xcode, simulator upgrade 16.0, running flutter error
 
 Run the sh script in your flutter project under the root path to automatically fix flutter_inappwebview library errors
 
-
+-> fixed: `sh fixios18.sh`
 
 ## for 中文 : 
 修复iOS 18 xcode、模拟器升级16.0, 运行flutter报错
 
 将本项目中sh脚本放到你的flutter项目根路径下执行,自动修复flutter_inappwebview库的报错
 
+# Xcode 16 issue some libraries firebase
+
+Issue: `Lexical or Preprocessor Issue (Xcode): Include of non-modular header inside framework module 'firebase_crashlytics.Crashlytics_Platform': `
+
+
+## Fixed: `ruby fixxcode16.rb`

--- a/fixxcode16.rb
+++ b/fixxcode16.rb
@@ -1,0 +1,24 @@
+require 'xcodeproj'
+
+# Path to your project's .xcodeproj file
+project_path = 'ios/Runner.xcodeproj'
+
+# Name of the target you want to modify
+target_name = 'Runner'
+
+# Open the Xcode project
+project = Xcodeproj::Project.open(project_path)
+
+# Find the target by name
+target = project.targets.find { |t| t.name == target_name }
+
+# Loop through each build configuration (e.g., Debug, Release)
+target.build_configurations.each do |config|
+  # Set the CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES to 'YES'
+  config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+end
+
+# Save the updated project
+project.save
+
+puts "Updated CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES to 'YES' for target '#{target_name}'"


### PR DESCRIPTION
Log error sample:
```
Lexical or Preprocessor Issue (Xcode): Include of non-modular header inside framework module 'firebase_crashlytics.Crashlytics_Platform': '/Volumes/Projects/ABC/ios/Pods/Headers/Public/Firebase/Firebase.h'
/Users/trantrunghieu/.pub-cache/hosted/pub.dev/firebase_crashlytics-3.5.7/ios/Classes/Crashlytics_Platform.h:20:8

Lexical or Preprocessor Issue (Xcode): Include of non-modular header inside framework module 'firebase_crashlytics.ExceptionModel_Platform': '/Volumes//Projects/ABC/ios/Pods/Headers/Public/Firebase/Firebase.h'
/Users/trantrunghieu/.pub-cache/hosted/pub.dev/firebase_crashlytics-3.5.7/ios/Classes/ExceptionModel_Platform.h:20:8

```